### PR TITLE
Fix npm peer conflict for Motion One

### DIFF
--- a/image-slider-app/package-lock.json
+++ b/image-slider-app/package-lock.json
@@ -20,7 +20,7 @@
         "react-image-gallery": "^1.4.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4",
-        "@motionone/react": "^10.16.0"
+        "@motionone/react": "^11.0.0"
       },
       "devDependencies": {
         "tailwindcss": "^3.4.1"

--- a/image-slider-app/package.json
+++ b/image-slider-app/package.json
@@ -19,7 +19,7 @@
     "@mui/icons-material": "^5.15.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "@motionone/react": "^10.16.0"
+    "@motionone/react": "^11.0.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- bump `@motionone/react` to a version that supports React 18

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*